### PR TITLE
Ability to add tiles to the exact center of grids completed:

### DIFF
--- a/SKImageGrid.xcodeproj/project.pbxproj
+++ b/SKImageGrid.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		74A0168426B71269004DFEBE /* SteppableSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0168326B71269004DFEBE /* SteppableSlider.swift */; };
 		74A0168626B712BE004DFEBE /* ImageNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0168526B712BE004DFEBE /* ImageNode.swift */; };
 		74A0168726B717A1004DFEBE /* SKImageGridViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0167726B706FD004DFEBE /* SKImageGridViewModel.swift */; };
+		74A0168A26B75DFA004DFEBE /* XTileNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0168926B75DFA004DFEBE /* XTileNode.swift */; };
 		74A8966826B4563F00E828FF /* SKImageGridApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A8965A26B4563E00E828FF /* SKImageGridApp.swift */; };
 		74A8966926B4563F00E828FF /* SKImageGridApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A8965A26B4563E00E828FF /* SKImageGridApp.swift */; };
 		74A8966A26B4563F00E828FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A8965B26B4563E00E828FF /* ContentView.swift */; };
@@ -34,6 +35,7 @@
 		74A0168126B71241004DFEBE /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		74A0168326B71269004DFEBE /* SteppableSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteppableSlider.swift; sourceTree = "<group>"; };
 		74A0168526B712BE004DFEBE /* ImageNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNode.swift; sourceTree = "<group>"; };
+		74A0168926B75DFA004DFEBE /* XTileNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XTileNode.swift; sourceTree = "<group>"; };
 		74A8965A26B4563E00E828FF /* SKImageGridApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKImageGridApp.swift; sourceTree = "<group>"; };
 		74A8965B26B4563E00E828FF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		74A8965C26B4563F00E828FF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 				74A0167926B70B28004DFEBE /* MapScene.swift */,
 				74A0167F26B70D45004DFEBE /* MapGrideNode.swift */,
 				74A0168526B712BE004DFEBE /* ImageNode.swift */,
+				74A0168926B75DFA004DFEBE /* XTileNode.swift */,
 			);
 			path = Sprites;
 			sourceTree = "<group>";
@@ -240,6 +243,7 @@
 				74A0168426B71269004DFEBE /* SteppableSlider.swift in Sources */,
 				74A0167C26B70B79004DFEBE /* CGSizeExtension.swift in Sources */,
 				74A0168026B70D45004DFEBE /* MapGrideNode.swift in Sources */,
+				74A0168A26B75DFA004DFEBE /* XTileNode.swift in Sources */,
 				74A0168226B71241004DFEBE /* ImagePicker.swift in Sources */,
 				74A8966826B4563F00E828FF /* SKImageGridApp.swift in Sources */,
 				74A0167826B706FD004DFEBE /* SKImageGridViewModel.swift in Sources */,

--- a/Shared/Extensions/CGSizeExtension.swift
+++ b/Shared/Extensions/CGSizeExtension.swift
@@ -8,11 +8,28 @@
 import SwiftUI
 
 extension CGSize {
-    func add(width: CGFloat, height: CGFloat) -> CGSize {
-        return CGSize(width: self.width + width, height: self.height + height)
+    
+    struct PointSystem {
+        var topLeft: CGPoint
+        var topRight: CGPoint
+        var center: CGPoint
+        var bottomLeft: CGPoint
+        var bottomRight: CGPoint
+        
+        init(_ size: CGSize) {
+            self.topLeft = CGPoint(x: 0, y: 0)
+            self.topRight = CGPoint(x: size.width, y: 0)
+            self.center = CGPoint(x: size.width / 2, y: size.height / 2)
+            self.bottomLeft = CGPoint(x: 0, y: size.height)
+            self.bottomRight = CGPoint(x: size.width, y: size.height)
+        }
     }
     
-    func midPoint() -> CGPoint {
-        return CGPoint(x: width / 2, y: height / 2)
+    var point: PointSystem {
+        return PointSystem(self)
+    }
+    
+    func add(width: CGFloat, height: CGFloat) -> CGSize {
+        return CGSize(width: self.width + width, height: self.height + height)
     }
 }

--- a/Shared/Views/Sprites/MapGrideNode.swift
+++ b/Shared/Views/Sprites/MapGrideNode.swift
@@ -12,7 +12,6 @@ class MapGridNode: SKSpriteNode {
     var rows: Int!
     var columns: Int!
     var gridSize: CGFloat
-    var offset: CGPoint = .zero
     
     init?(gridSize: CGFloat, imageSize: CGSize) {
         let newSize = imageSize.add(width: 50.0, height: 50.0)
@@ -62,11 +61,9 @@ class MapGridNode: SKSpriteNode {
     }
     
     func gridPosition(row: Int, column: Int) -> CGPoint {
-        let offset = gridSize / 2.0 + 0.5
-        let xSize = CGFloat(column) * gridSize
-        let x = xSize - (gridSize * CGFloat(columns)) / 2.0 + CGFloat(offset)
-        let ySize = CGFloat(rows - row - 1) * gridSize
-        let y = ySize - (gridSize * CGFloat(rows)) / 2.0 + CGFloat(offset)
+        let gridOffset = gridSize / 2.0 + 0.5
+        let x = (CGFloat(row) * gridSize) + gridOffset
+        let y = (CGFloat(column) * gridSize) + gridOffset
         return CGPoint(x: x, y: y)
     }
     

--- a/Shared/Views/Sprites/MapScene.swift
+++ b/Shared/Views/Sprites/MapScene.swift
@@ -14,10 +14,11 @@ class MapScene: SKScene {
     private var startMovementPoint = CGPoint.zero
     
     private var centerPoint: CGPoint {
-        return size.midPoint()
+        return size.point.center
     }
     
     private var backgroundNode: ImageNode!
+    private var tiles: [XTileNode] = []
     private var mapGridNode: MapGridNode!
     private var cameraNode: SKCameraNode = SKCameraNode()
     
@@ -66,7 +67,27 @@ class MapScene: SKScene {
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        return
+        if touches.count == 1 {
+            guard let touch = touches.first else { return }
+            if let mapGrid = self.childNode(withName: "MapGrid") as? MapGridNode {
+                let indexPath = mapGrid.indexPath(ofPoint: touch.location(in: self))
+                let point = mapGrid.gridPosition(row: indexPath.row, column: indexPath.section)
+                let removeNodes = nodes(at: point)
+                
+                if let node = removeNodes.first(where: { $0.name != "MapGrid" && $0.name != "Background" }) {
+                    node.removeFromParent()
+                    tiles.removeAll(where: { $0 == node })
+                } else {
+                    guard let xTile = XTileNode(gridSize: mapGridNode.gridSize) else { return }
+                    print(mapGrid.size, size)
+                    tiles.append(xTile)
+                    xTile.name = "\(tiles.count)"
+                    xTile.position = point
+                    xTile.zPosition = 3
+                    self.addChild(xTile)
+                }
+            }
+        }
     }
     
     func updateMapGrid(gridSize: CGFloat, offset: CGPoint) {
@@ -102,7 +123,7 @@ class MapScene: SKScene {
     }
     
     @objc func panAction(_ sender: UIPanGestureRecognizer) {
-        if sender.numberOfTouches == 1 {
+        if sender.numberOfTouches == 2 {
             if sender.state == .began {
                 startMovementPoint = sender.location(in: view)
             }

--- a/Shared/Views/Sprites/XTileNode.swift
+++ b/Shared/Views/Sprites/XTileNode.swift
@@ -1,0 +1,41 @@
+//
+//  XTileNode.swift
+//  XTileNode
+//
+//  Created by Brett Chapin on 8/1/21.
+//
+
+import SwiftUI
+import SpriteKit
+
+class XTileNode: SKSpriteNode {
+    init?(gridSize: CGFloat) {
+        guard let texture = XTileNode.drawX(gridSize: gridSize) else { return nil }
+        super.init(texture: texture, color: .clear, size: texture.size())
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    class func drawX(gridSize: CGFloat) -> SKTexture? {
+        let size = CGSize(width: gridSize, height: gridSize)
+        UIGraphicsBeginImageContext(size)
+        guard let context = UIGraphicsGetCurrentContext() else { return nil }
+        
+        let bezierPath = UIBezierPath()
+        
+        bezierPath.move(to: size.point.topRight)
+        bezierPath.addLine(to: size.point.bottomLeft)
+        bezierPath.move(to: size.point.topLeft)
+        bezierPath.addLine(to: size.point.bottomRight)
+        
+        SKColor.red.setStroke()
+        bezierPath.lineWidth = 5.0
+        bezierPath.stroke()
+        context.addPath(bezierPath.cgPath)
+        guard let image = UIGraphicsGetImageFromCurrentImageContext() else { return nil }
+        UIGraphicsEndImageContext()
+        
+        return SKTexture(image: image)
+    }
+}

--- a/Shared/Views/SteppableSlider.swift
+++ b/Shared/Views/SteppableSlider.swift
@@ -28,6 +28,7 @@ struct SteppableSlider: View {
             }
 
         }
+        .padding(.horizontal)
     }
     
 }

--- a/Shared/Views/ViewModels/SKImageGridViewModel.swift
+++ b/Shared/Views/ViewModels/SKImageGridViewModel.swift
@@ -12,17 +12,23 @@ class SKImageGridViewModel: ObservableObject {
     
     @Published var size: CGFloat = 10.0 {
         didSet {
-            scene.updateMapGrid(gridSize: size, offset: gridOffset)
+            if image != nil {
+                scene.updateMapGrid(gridSize: size, offset: gridOffset)
+            }
         }
     }
     @Published var xOffset: CGFloat = 0.0 {
         didSet {
-            scene.updateMapGrid(gridSize: size, offset: gridOffset)
+            if image != nil {
+                scene.updateMapGrid(gridSize: size, offset: gridOffset)
+            }
         }
     }
     @Published var yOffset: CGFloat = 0.0 {
         didSet {
-            scene.updateMapGrid(gridSize: size, offset: gridOffset)
+            if image != nil {
+                scene.updateMapGrid(gridSize: size, offset: gridOffset)
+            }
         }
     }
     @Published var presentPicker: Bool = false
@@ -33,6 +39,6 @@ class SKImageGridViewModel: ObservableObject {
     }
     @Published var scene: MapScene!
     private var gridOffset: CGPoint {
-        return CGPoint(x: -xOffset, y: -yOffset)
+        return CGPoint(x: -xOffset, y: -yOffset - size / 2)
     }
 }


### PR DESCRIPTION
* Notes
   ! This functionality has issues with the two gesture recognizers. Look into
     another way of implementing either the tile addition or the recognizers.

+ XTileNode
   + drawX(gridSize:) -> SKTexture?

~ SKImageGridViewModel
   ~ size: CGFloat, changing this property before setting the image no longer
     crashes the app.
   ~ xOffset: CGFloat, changing this property before setting the image no longer
     crashes the app.
   ~ yOffset: CGFloat, changing this property before setting the image no longer
     crashes the app.
   ~ gridOffset: CGPoint, now incorperates the offset created by the grid (for
     some reason it was offset half of the gridSize positive in the y direction)

~ CGSizeExtension
   + PointSystem, a new struct to make accessing the corners and center CGPoints
     of a CGSize easier.
   + point: PointSystem

~ MapScene
   ~ centerPoint: CGPoint, now uses the updated CGSize extension.
   + tiles: [XTileNode]
   ~ touchesBegan(_:, with:), now handles touches. Adding/Removing XTiles from
     the grid.

~ MapGridNode
   ~ gridPosition(row:, column:) -> CGPoint, now calculates the correct point
     within the grid, centered within a row and column.

~ SteppableSlider
   ~ body: some View, now has padding on the left and right of the VStack to
     make it look a little prettier.