### PR TITLE
Added the ability to trace paths with a green transparent squares:

### DIFF
--- a/SKImageGrid.xcodeproj/project.pbxproj
+++ b/SKImageGrid.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		74A0168626B712BE004DFEBE /* ImageNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0168526B712BE004DFEBE /* ImageNode.swift */; };
 		74A0168726B717A1004DFEBE /* SKImageGridViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0167726B706FD004DFEBE /* SKImageGridViewModel.swift */; };
 		74A0168A26B75DFA004DFEBE /* XTileNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0168926B75DFA004DFEBE /* XTileNode.swift */; };
+		74A0168C26B789DF004DFEBE /* PathTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A0168B26B789DE004DFEBE /* PathTile.swift */; };
 		74A8966826B4563F00E828FF /* SKImageGridApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A8965A26B4563E00E828FF /* SKImageGridApp.swift */; };
 		74A8966926B4563F00E828FF /* SKImageGridApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A8965A26B4563E00E828FF /* SKImageGridApp.swift */; };
 		74A8966A26B4563F00E828FF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A8965B26B4563E00E828FF /* ContentView.swift */; };
@@ -36,6 +37,7 @@
 		74A0168326B71269004DFEBE /* SteppableSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SteppableSlider.swift; sourceTree = "<group>"; };
 		74A0168526B712BE004DFEBE /* ImageNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageNode.swift; sourceTree = "<group>"; };
 		74A0168926B75DFA004DFEBE /* XTileNode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XTileNode.swift; sourceTree = "<group>"; };
+		74A0168B26B789DE004DFEBE /* PathTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PathTile.swift; sourceTree = "<group>"; };
 		74A8965A26B4563E00E828FF /* SKImageGridApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKImageGridApp.swift; sourceTree = "<group>"; };
 		74A8965B26B4563E00E828FF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		74A8965C26B4563F00E828FF /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				74A0167F26B70D45004DFEBE /* MapGridNode.swift */,
 				74A0168526B712BE004DFEBE /* ImageNode.swift */,
 				74A0168926B75DFA004DFEBE /* XTileNode.swift */,
+				74A0168B26B789DE004DFEBE /* PathTile.swift */,
 			);
 			path = Sprites;
 			sourceTree = "<group>";
@@ -236,6 +239,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				74A0168C26B789DF004DFEBE /* PathTile.swift in Sources */,
 				74A8966A26B4563F00E828FF /* ContentView.swift in Sources */,
 				74A0168626B712BE004DFEBE /* ImageNode.swift in Sources */,
 				74A0167A26B70B28004DFEBE /* MapScene.swift in Sources */,

--- a/Shared/Views/Sprites/PathTile.swift
+++ b/Shared/Views/Sprites/PathTile.swift
@@ -1,6 +1,6 @@
 //
-//  XTileNode.swift
-//  XTileNode
+//  PathTile.swift
+//  PathTile
 //
 //  Created by Brett Chapin on 8/1/21.
 //
@@ -8,9 +8,9 @@
 import SwiftUI
 import SpriteKit
 
-class XTileNode: SKSpriteNode {
+class PathTile: SKSpriteNode {
     init?(gridSize: CGFloat) {
-        guard let texture = XTileNode.drawX(gridSize: gridSize) else { return nil }
+        guard let texture = PathTile.drawTile(gridSize: gridSize) else { return nil }
         super.init(texture: texture, color: .clear, size: texture.size())
     }
     
@@ -18,21 +18,21 @@ class XTileNode: SKSpriteNode {
         super.init(coder: aDecoder)
     }
     
-    class func drawX(gridSize: CGFloat) -> SKTexture? {
+    class func drawTile(gridSize: CGFloat) -> SKTexture? {
         let size = CGSize(width: gridSize, height: gridSize)
         UIGraphicsBeginImageContext(size)
         guard let context = UIGraphicsGetCurrentContext() else { return nil }
         
         let bezierPath = UIBezierPath()
         
-        bezierPath.move(to: size.point.topRight)
-        bezierPath.addLine(to: size.point.bottomLeft)
         bezierPath.move(to: size.point.topLeft)
+        bezierPath.addLine(to: size.point.topRight)
         bezierPath.addLine(to: size.point.bottomRight)
+        bezierPath.addLine(to: size.point.bottomLeft)
+        bezierPath.addLine(to: size.point.topLeft)
         
-        SKColor.red.setStroke()
-        bezierPath.lineWidth = 5.0
-        bezierPath.stroke()
+        SKColor.green.withAlphaComponent(0.3).setFill()
+        bezierPath.fill()
         context.addPath(bezierPath.cgPath)
         guard let image = UIGraphicsGetImageFromCurrentImageContext() else { return nil }
         UIGraphicsEndImageContext()

--- a/Shared/Views/ViewModels/SKImageGridViewModel.swift
+++ b/Shared/Views/ViewModels/SKImageGridViewModel.swift
@@ -39,6 +39,6 @@ class SKImageGridViewModel: ObservableObject {
     }
     @Published var scene: MapScene!
     private var gridOffset: CGPoint {
-        return CGPoint(x: -xOffset, y: -yOffset - size / 2)
+        return CGPoint(x: -xOffset, y: -yOffset)
     }
 }


### PR DESCRIPTION
~ SKImageGridViewModel
   ~ gridOffset: CGPoint, had to remove the slight offset created to lower the
     grid into the appropriate place.

~ MapScene
   * Note: Due to how I created the touchesEnded function, it will also remove
     path tiles when they are tapped as well.
   + offset: CGPoint
   ~ init(image:, gridSize:, offset:)
   ~ touchesEnded(_:, with:)
   ~ updateMapGrid(gridSize:, offset:)
   ~ padAction(_:), now handles 1 finger panning which enables the path creation
     functionality.

+ PathTile
   * Note: This is a simple SKSpriteNode that has a draw function that creates
     a green square texture during initialization for itself.